### PR TITLE
Fixed WPKirk admin views

### DIFF
--- a/resources/views/dashboard/api.php
+++ b/resources/views/dashboard/api.php
@@ -60,7 +60,7 @@ if (!defined('ABSPATH')) {
 
 
     <p>You can try the API <code class="language- inline">/wp-json/wpkirk/v1/example</code> <a target="_blank"
-        href="/wp-json/wpkirk/v1/example">here</a></p>
+        href="<?php echo get_site_url(); ?>/wp-json/wpkirk/v1/example">here</a></p>
 
     <a name="http-methods"></a>
     <h2>HTTP Methods</h2>

--- a/resources/views/dashboard/api.php
+++ b/resources/views/dashboard/api.php
@@ -28,8 +28,7 @@ if (!defined('ABSPATH')) {
 
     <!-- Current options -->
     <hr />
-    <a name="rest-api"></a>
-    <h2>REST API</h2>
+    <h2 id="rest-api">REST API</h2>
 
     <p>From release v0.13+ WPBones provides a simple way to handle the WordPress Rest API.</p>
     <p>To create your custom API, you have to create a new folder into <code class="language- inline">/api</code> in the root of your plugin. The
@@ -40,8 +39,7 @@ if (!defined('ABSPATH')) {
       <pre><code class="language-sh">/api/vendor/v1</code></pre>
 
 
-    <a name="routing"></a>
-    <h2>Routing</h2>
+    <h2 id="routing">Routing</h2>
 
     <p>Now, we can start to create the Rest API route by adding a new file in the our structure. For example, we'll use
       <code class="language-sh inline">route.php</code>
@@ -62,8 +60,7 @@ if (!defined('ABSPATH')) {
     <p>You can try the API <code class="language- inline">/wp-json/wpkirk/v1/example</code> <a target="_blank"
         href="<?php echo get_site_url(); ?>/wp-json/wpkirk/v1/example">here</a></p>
 
-    <a name="http-methods"></a>
-    <h2>HTTP Methods</h2>
+    <h2 id="http-methods">HTTP Methods</h2>
     <p>The Route class supports the following HTTP methods: <code class="language- inline">get</code>, <code class="language- inline">post</code>, <code class="language- inline">put</code>,
       <code class="language- inline">patch</code>, <code class="language- inline">delete</code> In short, the same supported by the WordPress REST API and defined in the
       <code class="language- inline">WP_REST_Server</code> class.

--- a/resources/views/dashboard/assets.php
+++ b/resources/views/dashboard/assets.php
@@ -23,7 +23,6 @@
     <h2>Assets</h2>
 
     <p>WP Bones provides a simple way to include assets in your plugin. You can include styles and scripts in the admin area and in the public area.</p>
-    </p>
 
     <a name="styles"></a>
     <h3>Styles</h3>

--- a/resources/views/dashboard/assets.php
+++ b/resources/views/dashboard/assets.php
@@ -24,8 +24,7 @@
 
     <p>WP Bones provides a simple way to include assets in your plugin. You can include styles and scripts in the admin area and in the public area.</p>
 
-    <a name="styles"></a>
-    <h3>Styles</h3>
+    <h3 id="styles">Styles</h3>
 
     <p>Currently, WP Bones supports the following styles: standard CSS files, SCSS files, and LESS files.
     You may create your styles in the <code class="language-bash inline">resources/assets/css</code> directory.</p>
@@ -39,14 +38,12 @@
     ->withAdminStyles('my-styles');
   }</code></pre>
 
-  <a name="javascript"></a>
-  <h3>Javascript</h3>
+  <h3 id="javascript">Javascript</h3>
 
   <p>Javascript files work in the same way as styles. You can create your javascript files in the <code class="language-bash inline">resources/assets/js</code> directory.</p>
   <p>You can find more details in the <a href="https://wpbones.vercel.app/docs/GettingStarted/assets">Assets documentation</a>.</p>
 
-  <a name="react"></a>
-  <h3>ReactJS and Typescript</h3>
+  <h3 id="react">ReactJS and Typescript</h3>
 
   <p>You may use gulp to compile simple React components. you will be able to compile .jsx files and .tsx files. The compiled files will be in the <code class="language-html inline">public/js</code> directory.</p>
 

--- a/resources/views/dashboard/database.php
+++ b/resources/views/dashboard/database.php
@@ -14,12 +14,14 @@
 
   <div class="wp-kirk-toc clearfix">
     <ul>
-      <li><a href="#">Query Builder</a></li>
+      <li><a href="#query-builder">Query Builder</a></li>
       <li><a href="#example">Example</a></li>
     </ul>
   </div>
 
   <div class="wp-kirk-toc-content">
+
+    <h2 id="query-builder">Query Builder</h2>
 
     <p>WP Bones's database query builder provides a convenient, fluent interface to creating and running database
       queries. It can be used to perform most database operations in your WordPress instance.</p>
@@ -30,8 +32,7 @@
       ->all()
       ->dump(); ?></code></pre>
 
-    <a name="example"></a>
-    <h2>Example</h2>
+    <h2 id="example">Example</h2>
 
 <pre><code class="language-php">foreach (DB::table('users')->get() as $user) {
   echo "{$user->user_login}\n";

--- a/resources/views/dashboard/html.php
+++ b/resources/views/dashboard/html.php
@@ -9,7 +9,7 @@
 
 <div class="wp-kirk wrap wp-kirk-sample">
 
-  <h1>Html Tags Support</h1>
+  <h1>HTML Tags Support</h1>
 
   <div class="wp-kirk-toc clearfix">
     <ul>
@@ -30,10 +30,9 @@
 
   <div class="wp-kirk-toc-content">
 
-    <p>Here you'll find some example about Html support.</p>
+    <p>Here you'll find some example about HTML support.</p>
 
-    <a name="facade"></a>
-    <h2>Html facade</h2>
+    <h2 id="facade">Html facade</h2>
 
     <p>You can render a HTML component in different ways</p>
 
@@ -43,10 +42,9 @@
       <?php echo WPKirk\Html::button('Hello, world!'); ?>
     </div>
 
-    <a name="fluent"></a>
     <hr />
 
-    <h2>Fluent Example</h2>
+    <h2 id="fluent">Fluent Example</h2>
 
     <pre><code class="language-php">$html = WPKirk\Html::button( "Hello, world!" )->html();
 echo $html;</code></pre>
@@ -120,8 +118,7 @@ echo $button;</code></pre>
 
     <hr />
 
-    <a name="styles"></a>
-    <h2>Styles</h2>
+    <h2 id="styles">Styles</h2>
 
     <p>You may change the HTML component styles immediately by using <code class="language-php inline">style()</code></p>
 
@@ -153,8 +150,7 @@ echo $button;</code></pre>
 
     <hr />
 
-    <a name="a"></a>
-    <h2>Available HTML tags</h2>
+    <h2 id="a">Available HTML tags</h2>
 
     <h3>a</h3>
 
@@ -166,8 +162,7 @@ echo $button;</code></pre>
 
     <hr />
 
-    <a name="button"></a>
-    <h3>button</h3>
+    <h3 id="button">button</h3>
 
     <pre><code class="language-php">echo WPKirk\Html::button('Hello, world!')->class('button button-primary')</code></pre>
 
@@ -179,8 +174,7 @@ echo $button;</code></pre>
 
     <hr />
 
-    <a name="form"></a>
-    <h3>Form</h3>
+    <h3 id="form">Form</h3>
 
     <pre><code class="language-php">echo WPKirk\Html::form()->acceptcharset('ISO-8859-1')</code></pre>
 
@@ -190,8 +184,7 @@ echo $button;</code></pre>
 
     <hr />
 
-    <a name="input"></a>
-    <h3>Input</h3>
+    <h3 id="input">Input</h3>
 
     <pre><code class="language-php">echo WPKirk\Html::input()->type('text')->value('Hello')</code></pre>
 
@@ -201,8 +194,7 @@ echo $button;</code></pre>
 
     <hr />
 
-    <a name="checkbox"></a>
-    <h3>Checkbox</h3>
+    <h3 id="checkbox">Checkbox</h3>
 
     <pre><code class="language-php">echo WPKirk\Html::checkbox()->name('myname')->value('Hello')</code></pre>
 
@@ -216,10 +208,9 @@ echo $button;</code></pre>
 &lt;input type=&quot;checkbox&quot; name=&quot;myname&quot; value=&quot;Hello&quot; /&gt;
 </code></pre>
 
-    <a name="select"></a>
     <hr />
 
-    <h3>Select</h3>
+    <h3 id="select">Select</h3>
 
     <p>To use a <code class="language-html inline">select</code> you have to define the options as well. Below, you'll see different ways to do that.
       The first
@@ -271,10 +262,9 @@ echo $button;</code></pre>
         ->selected('item-5'); ?>
     </div>
 
-    <a name="textarea"></a>
     <hr />
 
-    <h3>Textarea</h3>
+    <h3 id="textarea">Textarea</h3>
 
     <pre><code class="language-php">echo WPKirk\Html::textarea('Hi there, How are you?')</code></pre>
 
@@ -282,10 +272,9 @@ echo $button;</code></pre>
       <?php echo WPKirk\Html::textarea('Hi there, How are you?'); ?>
     </div>
 
-    <a name="datetime"></a>
     <hr />
 
-    <h3>Datetime</h3>
+    <h3 id="datetime">Datetime</h3>
 
     <div>
 
@@ -312,10 +301,9 @@ echo $button;</code></pre>
       <?php echo WPKirk\Html::datetime()->value('2015-11-10 12:13'); ?>
     </div>
 
-    <a name="custom-attributes"></a>
     <hr />
 
-    <h2>Custom attributes</h2>
+    <h2 id="custom-attributes">Custom attributes</h2>
 
     <p>You may also set any custom attributes in the HTML component</p>
 

--- a/resources/views/dashboard/index.php
+++ b/resources/views/dashboard/index.php
@@ -15,7 +15,7 @@
     <ul>
       <li><a href="#passing-data">Passing data to view</a></li>
       <li><a href="#configuration">Configuration</a></li>
-      <li><a href="#plugin-information">Plugin information</a></li>
+      <li><a href="#plugin-info">Plugin information</a></li>
       <li><a href="#custom-pages">Custom Pages</a></li>
     </ul>
   </div>
@@ -30,15 +30,13 @@
     <h3>PHP Version <?php echo phpversion(); ?></h3>
 
     <hr />
-    <a name="passing-data"></a>
-    <h2>Passing data to view</h2>
+    <h2 id="passing-data">Passing data to view</h2>
 
     <p>You may get variable from the controller. For example, the variable <code class="language- inline">kirk</code> is <?php echo $kirk; ?>
     </p>
 
     <hr />
-    <a name="configuration"></a>
-    <h2>Configuration</h2>
+    <h2 id="configuration">Configuration</h2>
     <p>Get the <code class="language- inline">custom</code> configuration by using</p>
 
     <pre><code class="language-php">&lt;?php echo $plugin-&gt;config('custom.sample') ?&gt;</code></pre>
@@ -48,8 +46,7 @@
     <pre><code class="language-"><?php echo $plugin->config("custom.sample"); ?></code></pre>
 
     <hr />
-    <a name="plugin-information"></a>
-    <h2>Plugin information</h2>
+    <h2 id="plugin-info">Plugin information</h2>
     <p>You may get the plugin information by using</p>
 
 
@@ -62,8 +59,7 @@
     <pre><code class="language-php">&lt;?php echo $plugin-&gt;TextDomain ?&gt; // <?php echo $plugin->TextDomain; ?></code></pre>
 
     <hr />
-    <a name="custom-pages"></a>
-    <h2>Custom Pages</h2>
+    <h2 id="custom-pages">Custom Pages</h2>
 
     <p>To create a custom pages without a menu, you may config the <code class="language- inline">route.php</code> file in the
       <code class="language- inline">config</code>

--- a/resources/views/dashboard/model.php
+++ b/resources/views/dashboard/model.php
@@ -10,11 +10,11 @@
 
 <div class="wp-kirk wrap wp-kirk-sample">
 
-  <h1>Model</h1>
+  <h1 id="model">Model</h1>
 
   <div class="wp-kirk-toc clearfix">
     <ul>
-      <li><a href="#">Model</a></li>
+      <li><a href="#model">Model</a></li>
       <li><a href="#example">Example</a></li>
     </ul>
   </div>
@@ -55,7 +55,7 @@ class MyPluginProducts extends Model
   protected $table = 'my_plugin_products';
 }</code></pre>
 
-    <h2>Example</h2>
+    <h2 id="example">Example</h2>
 
     <pre><code class="language-php">&lt;?php MyPluginProducts::all()</code></pre>
 

--- a/resources/views/dashboard/options.php
+++ b/resources/views/dashboard/options.php
@@ -13,7 +13,7 @@
 
   <div class="wp-kirk-toc clearfix">
     <ul>
-      <li><a href="#current-options">Current Option</a></li>
+      <li><a href="#current-options">Current Options</a></li>
       <li><a href="#update">Update Options</a></li>
       <li><a href="#add">Add Options</a></li>
       <li><a href="#mass-update">Mass Update</a></li>
@@ -27,8 +27,7 @@
 
     <!-- Current options -->
     <hr />
-    <a name="current-options"></a>
-    <h2>Current option</h2>
+    <h2 id="current-options">Current options</h2>
 
     <p>Here you can see he current options are:</p>
 
@@ -83,8 +82,7 @@
 
     <!-- Update -->
     <hr />
-    <a name="update"></a>
-    <h2>Update</h2>
+    <h2 id="update">Update</h2>
     <p>You may update any options and branch tree in the same way, by using the dot notation</p>
 
     <pre><code class="language-php">$plugin->options->set( 'Special.Name', 'John' );</code></pre>
@@ -121,8 +119,7 @@
 
     <!-- Add -->
     <hr />
-    <a name="add"></a>
-    <h2>Add</h2>
+    <h2 id="add">Add</h2>
     <p>Of course, adding new options will work in the same way by using the dot notation</p>
 
     <?php $plugin->options->set('Special.time', time()); ?>
@@ -145,8 +142,7 @@
 
     <!-- Mass Update -->
     <hr />
-    <a name="mass-update"></a>
-    <h3>Mass update</h3>
+    <h3 id="mass-update">Mass update</h3>
     <p>In according with the options structure, you may also update a whole sub set of options instead of change them
       individually</p>
 
@@ -171,8 +167,7 @@
 
     <!-- Mass Insert -->
     <hr />
-    <a name="mass-insert"></a>
-    <h3>Mass insert</h3>
+    <h3 id="mass-insert">Mass insert</h3>
     <p>Of course, you may use the mass feature for the insert as well</p>
 
     <?php $plugin->options->update([
@@ -198,8 +193,7 @@
 
     <!-- Delete -->
     <hr />
-    <a name="delete"></a>
-    <h2>Delete</h2>
+    <h2 id="delete">Delete</h2>
     <p>You may delete an option or a set of options by using the <code>set()</code> method along with <code>null</code>
     </p>
 
@@ -228,8 +222,7 @@
 
     <!-- Reset -->
     <hr />
-    <a name="reset"></a>
-    <h2>Reset to default</h2>
+    <h2 id="reset">Reset to default</h2>
     <p>Don't worry, we can reset everything by using the original file</p>
 
     <?php $plugin->options->reset(); ?>

--- a/resources/views/dashboard/package.php
+++ b/resources/views/dashboard/package.php
@@ -23,16 +23,14 @@
     </p>
 
     <hr />
-    <a name="your-package"></a>
-    <h2>Create your Package</h2>
+    <h2 id="your-package">Create your Package</h2>
 
     <pre><code class="language-php">&lt;?php WPKirk\YourPackage\YourPackageProvider::yourPackageMethod(); ?&gt;</code></pre>
 
     <?php WPKirk\YourPackage\YourPackageProvider::yourPackageMethod(); ?>
 
     <hr />
-    <a name="pure-css-tabs"></a>
-    <h2>Pure CSS Tabs</h2>
+    <h2 id="pure-css-tabs">Pure CSS Tabs</h2>
 
     <p>
       Here we are using the <a href="https://github.com/wpbones/pure-css-tabs">Pure CSS Tabs</a> package.
@@ -108,8 +106,7 @@ EOT;
 
     <hr />
 
-    <a name="pure-css-switch"></a>
-    <h2>Pure CSS Switch Button</h2>
+    <h2 id="pure-css-switch">Pure CSS Switch Button</h2>
 
     <p>
       Here we are using the <a href="https://github.com/wpbones/pure-css-switch">Pure CSS Switch</a> package.
@@ -215,9 +212,8 @@ EOT;
     </p>
 
     <hr>
-    <a name="user-agent"></a>
 
-    <h2>User Agent</h2>
+    <h2 id="user-agent">User Agent</h2>
 
     <p>You may use this package to extend WP Bones with a Mobile Detect Library.</p>
 


### PR DESCRIPTION
- In HTML 5, the anchor name tag is deprecated and should not be used: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#name
- Fixed an API example URL when WordPress is installed in a subdirectory.
- Removed an unnecessary paragraph closing tag which was never opened.