### PR TITLE
🐛 Fix deploy action names

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -28,12 +28,12 @@ add_action('wpbones_console_deploy_start', function ($console, $path) {
 }, 10, 2);
 
 /**
- * Fired before compile assets
+ * Fired before building assets
  *
  * @param object $console Instance of WPBones Console
  * @param string $path Destination path
  */
-add_action('wpbones_console_deploy_before_compile_assets', function ($console, $path) {
+add_action('wpbones_console_deploy_before_build_assets', function ($console, $path) {
   // Do something
 }, 10, 2);
 
@@ -48,12 +48,12 @@ add_filter('wpbones_console_deploy_gulp_production', function ($command) {
 });
 
 /**
- * Fired after compile assets
+ * Fired after building assets
  *
  * @param object $console Instance of WPBones Console
  * @param string $path Destination path
  */
-add_action('wpbones_console_deploy_after_compile_assets', function ($console, $path) {
+add_action('wpbones_console_deploy_after_build_assets', function ($console, $path) {
   // Do something
 }, 10, 2);
 


### PR DESCRIPTION
In the WP Bones `deploy` command the
`wpbones_console_deploy_before_compile_assets` was renamed to `wpbones_console_deploy_before_build_assets`
and
`wpbones_console_deploy_after_compile_assets` was renamed to `wpbones_console_deploy_after_build_assets`
but wasn't renamed in WP Kirk's `deploy.php`.

@gfazioli I can't find the `apply_filters` call for the `wpbones_console_deploy_gulp_production` filter. Was this removed or never added?